### PR TITLE
Log validation losses

### DIFF
--- a/spanet/network/jet_reconstruction/jet_reconstruction_network.py
+++ b/spanet/network/jet_reconstruction/jet_reconstruction_network.py
@@ -118,7 +118,7 @@ class JetReconstructionNetwork(JetReconstructionBase):
             classifications
         )
 
-    def predict(self, sources: Tuple[Source, ...]) -> Predictions:
+    def predict(self, sources: Tuple[Source, ...], validation=False) -> Predictions:
         with torch.no_grad():
             outputs = self.forward(sources)
 
@@ -145,12 +145,22 @@ class JetReconstructionNetwork(JetReconstructionBase):
                 for key, value in outputs.classifications.items()
             }
 
-        return Predictions(
-            assignments,
-            detections,
-            regressions,
-            classifications
-        )
+        # If self.predict is called from the validation loop, return the Predictions (Numpy arrays) and Outputs (Tensors)
+        # This is needed in order to use the tensors to compute losses and metrics.
+        if validation:
+            return Predictions(
+                assignments,
+                detections,
+                regressions,
+                classifications
+            ), Outputs(*outputs)
+        else:
+            return Predictions(
+                assignments,
+                detections,
+                regressions,
+                classifications
+            )
 
     def predict_assignments(self, sources: Tuple[Source, ...]) -> np.ndarray:
         # Run the base prediction step

--- a/spanet/network/jet_reconstruction/jet_reconstruction_network.py
+++ b/spanet/network/jet_reconstruction/jet_reconstruction_network.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import torch
 from torch import nn
@@ -118,7 +120,7 @@ class JetReconstructionNetwork(JetReconstructionBase):
             classifications
         )
 
-    def predict(self, sources: Tuple[Source, ...], validation=False) -> Predictions:
+    def predict(self, sources: Tuple[Source, ...]) -> Predictions:
         with torch.no_grad():
             outputs = self.forward(sources)
 
@@ -147,7 +149,8 @@ class JetReconstructionNetwork(JetReconstructionBase):
 
         # If self.predict is called from the validation loop, return the Predictions (Numpy arrays) and Outputs (Tensors)
         # This is needed in order to use the tensors to compute losses and metrics.
-        if validation:
+        caller_function = inspect.currentframe().f_back.f_code.co_name
+        if caller_function == "validation_step":
             return Predictions(
                 assignments,
                 detections,

--- a/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
+++ b/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
@@ -89,7 +89,7 @@ class JetReconstructionValidation(JetReconstructionNetwork):
         metrics["validation_accuracy"] = metrics[f"jet/accuracy_{num_targets}_of_{num_targets}"]
         return metrics
 
-    def compute_losses(self, outputs, batch):
+    def compute_validation_losses(self, outputs, batch):
         '''Compute and log the validation losses.'''
 
         symmetric_losses, best_indices = self.symmetric_losses(
@@ -159,7 +159,7 @@ class JetReconstructionValidation(JetReconstructionNetwork):
     def validation_step(self, batch, batch_idx) -> Dict[str, np.float32]:
         # Run the base prediction step
         sources, num_jets, targets, regression_targets, classification_targets = batch
-        (jet_predictions, particle_scores, regressions, classifications), outputs = self.predict(sources, validation=True)
+        (jet_predictions, particle_scores, regressions, classifications), outputs = self.predict(sources)
 
         batch_size = num_jets.shape[0]
         num_targets = len(targets)
@@ -215,7 +215,7 @@ class JetReconstructionValidation(JetReconstructionNetwork):
             if not np.isnan(value):
                 self.log(name, value, sync_dist=True)
 
-        self.compute_losses(outputs, batch)
+        self.compute_validation_losses(outputs, batch)
 
         return metrics
 

--- a/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
+++ b/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
@@ -89,6 +89,73 @@ class JetReconstructionValidation(JetReconstructionNetwork):
         metrics["validation_accuracy"] = metrics[f"jet/accuracy_{num_targets}_of_{num_targets}"]
         return metrics
 
+    def compute_losses(self, jet_predictions, particle_scores, targets, regression_targets, classification_targets):
+        '''Compute and log the validation losses.'''
+
+        symmetric_losses, best_indices = self.symmetric_losses(
+            jet_predictions,
+            particle_scores,
+            targets
+        )
+
+        # Construct the newly permuted masks based on the minimal permutation found during NLL loss.
+        permutations = self.event_permutation_tensor[best_indices].T
+        masks = torch.stack([target.mask for target in batch.assignment_targets])
+        masks = torch.gather(masks, 0, permutations)
+
+        # Default unity weight on correct device.
+        weights = torch.ones_like(symmetric_losses)
+
+        # Balance based on the particles present - only used in partial event training
+        if self.balance_particles:
+            class_indices = (masks * self.particle_index_tensor.unsqueeze(1)).sum(0)
+            weights *= self.particle_weights_tensor[class_indices]
+
+        # Balance based on the number of jets in this event
+        if self.balance_jets:
+            weights *= self.jet_weights_tensor[batch.num_vectors]
+
+        # Take the weighted average of the symmetric loss terms.
+        masks = masks.unsqueeze(1)
+        symmetric_losses = (weights * symmetric_losses).sum(-1) / torch.clamp(masks.sum(-1), 1, None)
+        assignment_loss, detection_loss = torch.unbind(symmetric_losses, 1)
+
+        with torch.no_grad():
+            for name, l in zip(self.training_dataset.assignments, assignment_loss):
+                self.log(f"validation_loss/{name}/assignment_loss", l, sync_dist=True)
+
+            for name, l in zip(self.training_dataset.assignments, detection_loss):
+                self.log(f"validation_loss/{name}/detection_loss", l, sync_dist=True)
+
+            if torch.isnan(assignment_loss).any():
+                raise ValueError("Assignment loss has diverged!")
+
+            if torch.isinf(assignment_loss).any():
+                raise ValueError("Assignment targets contain a collision.")
+
+        total_loss = []
+
+        if self.options.assignment_loss_scale > 0:
+            total_loss.append(assignment_loss)
+
+        if self.options.detection_loss_scale > 0:
+            total_loss.append(detection_loss)
+
+        if self.options.kl_loss_scale > 0:
+            total_loss = self.add_kl_loss(total_loss, jet_predictions, masks, weights)
+
+        if self.options.regression_loss_scale > 0:
+            total_loss = self.add_regression_loss(total_loss, regressions, regression_targets)
+
+        if self.options.classification_loss_scale > 0:
+            total_loss = self.add_classification_loss(total_loss, classifications, classification_targets)
+
+        total_loss = torch.cat([loss.view(-1) for loss in total_loss])
+
+        self.log("validation_loss/total_loss", total_loss.sum(), sync_dist=True)
+
+        return total_loss.mean()
+
     def validation_step(self, batch, batch_idx) -> Dict[str, np.float32]:
         # Run the base prediction step
         sources, num_jets, targets, regression_targets, classification_targets = batch
@@ -148,47 +215,13 @@ class JetReconstructionValidation(JetReconstructionNetwork):
             if not np.isnan(value):
                 self.log(name, value, sync_dist=True)
 
-        outputs = self.forward(batch.sources) # jet_reconstruction_network
-
-        symmetric_losses, best_indices = self.symmetric_losses(
-            outputs.assignments,
-            outputs.detections,
-            batch.assignment_targets
+        self.compute_losses(
+            jet_predictions,
+            particle_scores,
+            targets,
+            regression_targets,
+            classification_targets
         )
-
-        # Construct the newly permuted masks based on the minimal permutation found during NLL loss.
-        permutations = self.event_permutation_tensor[best_indices].T
-        masks = torch.stack([target.mask for target in batch.assignment_targets])
-        masks = torch.gather(masks, 0, permutations)
-
-        # Default unity weight on correct device.
-        weights = torch.ones_like(symmetric_losses)
-
-        # Balance based on the particles present - only used in partial event training
-        if self.balance_particles:
-            class_indices = (masks * self.particle_index_tensor.unsqueeze(1)).sum(0)
-            weights *= self.particle_weights_tensor[class_indices]
-
-        # Balance based on the number of jets in this event
-        if self.balance_jets:
-            weights *= self.jet_weights_tensor[batch.num_vectors]
-
-        # Take the weighted average of the symmetric loss terms.
-        masks = masks.unsqueeze(1)
-        symmetric_losses = (weights * symmetric_losses).sum(-1) / masks.sum(-1)
-        assignment_loss, detection_loss = torch.unbind(symmetric_losses, 1)
-
-        total_loss = []
-
-        if self.options.assignment_loss_scale > 0:
-            total_loss.append(assignment_loss)
-
-        if self.options.detection_loss_scale > 0:
-            total_loss.append(detection_loss)
-
-        total_loss = torch.cat([loss.view(-1) for loss in total_loss])
-
-        self.log("validation_loss/total_loss", total_loss.sum(), sync_dist=True)
 
         return metrics
 

--- a/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
+++ b/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
@@ -92,6 +92,12 @@ class JetReconstructionValidation(JetReconstructionNetwork):
     def compute_losses(self, jet_predictions, particle_scores, targets, regression_targets, classification_targets):
         '''Compute and log the validation losses.'''
 
+        # Cast arrays to torch tensors if they are not already.
+        if type(jet_predictions[0]) is not torch.Tensor:
+            jet_predictions = [torch.from_numpy(x).to("cuda") for x in jet_predictions]
+        if type(particle_scores[0]) is not torch.Tensor:
+            particle_scores = [torch.from_numpy(x).to("cuda") for x in particle_scores]
+
         symmetric_losses, best_indices = self.symmetric_losses(
             jet_predictions,
             particle_scores,

--- a/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
+++ b/spanet/network/jet_reconstruction/jet_reconstruction_validation.py
@@ -87,7 +87,6 @@ class JetReconstructionValidation(JetReconstructionNetwork):
         # Compute the sum accuracy of all complete events to act as our target for
         # early stopping, hyperparameter optimization, learning rate scheduling, etc.
         metrics["validation_accuracy"] = metrics[f"jet/accuracy_{num_targets}_of_{num_targets}"]
-
         return metrics
 
     def validation_step(self, batch, batch_idx) -> Dict[str, np.float32]:
@@ -148,6 +147,48 @@ class JetReconstructionValidation(JetReconstructionNetwork):
         for name, value in metrics.items():
             if not np.isnan(value):
                 self.log(name, value, sync_dist=True)
+
+        outputs = self.forward(batch.sources) # jet_reconstruction_network
+
+        symmetric_losses, best_indices = self.symmetric_losses(
+            outputs.assignments,
+            outputs.detections,
+            batch.assignment_targets
+        )
+
+        # Construct the newly permuted masks based on the minimal permutation found during NLL loss.
+        permutations = self.event_permutation_tensor[best_indices].T
+        masks = torch.stack([target.mask for target in batch.assignment_targets])
+        masks = torch.gather(masks, 0, permutations)
+
+        # Default unity weight on correct device.
+        weights = torch.ones_like(symmetric_losses)
+
+        # Balance based on the particles present - only used in partial event training
+        if self.balance_particles:
+            class_indices = (masks * self.particle_index_tensor.unsqueeze(1)).sum(0)
+            weights *= self.particle_weights_tensor[class_indices]
+
+        # Balance based on the number of jets in this event
+        if self.balance_jets:
+            weights *= self.jet_weights_tensor[batch.num_vectors]
+
+        # Take the weighted average of the symmetric loss terms.
+        masks = masks.unsqueeze(1)
+        symmetric_losses = (weights * symmetric_losses).sum(-1) / masks.sum(-1)
+        assignment_loss, detection_loss = torch.unbind(symmetric_losses, 1)
+
+        total_loss = []
+
+        if self.options.assignment_loss_scale > 0:
+            total_loss.append(assignment_loss)
+
+        if self.options.detection_loss_scale > 0:
+            total_loss.append(detection_loss)
+
+        total_loss = torch.cat([loss.view(-1) for loss in total_loss])
+
+        self.log("validation_loss/total_loss", total_loss.sum(), sync_dist=True)
 
         return metrics
 


### PR DESCRIPTION
We implement the logging of validation losses during training: now in the output tensorboard file we find the loss functions evaluated on the validation dataset, at the end of each epoch.
The losses are organized as follows in the output:
- In the `loss/` folder one finds the training loss, evaluated for each batch
- In the `validation_loss/` folder one finds the validation loss, evaluated for the whole validation dataset at each step

All the losses are implemented also in the validation, which means that if one adds a specific loss it will be logged both for the training and validation.

In this implementation, we modified the method `predict()` of `JetReconstructionNetwork` such that in the validation step it outputs lists of torch tensors instead of lists of numpy NDarray. The torch tensors are then passed to a new method `compute_validation_losses()` of the `JetReconstructionValidation` class that calls the different methods to compute different losses. These methods of `JetReconstructionTraining` had to be redefined in order to differentiate whether the training or validation loss has to be logged.